### PR TITLE
Fix return type warning in PHP 8.1+

### DIFF
--- a/src/DataSet/DefaultTableIterator.php
+++ b/src/DataSet/DefaultTableIterator.php
@@ -70,7 +70,7 @@ class DefaultTableIterator implements ITableIterator
      *
      * @return ITable|false
      */
-    public function current()
+    public function current() : mixed
     {
         return current($this->tables);
     }


### PR DESCRIPTION
Small fix for error message

```Deprecated: Return type of PHPUnit\DbUnit\DataSet\DefaultTableIterator::current() should either be compatible with Iterator::current(): mixed, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /var/www/www-root/vendor/misantron/dbunit/src/DataSet/DefaultTableIterator.php on line 73```